### PR TITLE
refactor the way of implementing / consuming a signal in component

### DIFF
--- a/dist/src/augment.d.ts
+++ b/dist/src/augment.d.ts
@@ -1,6 +1,6 @@
 type Signal<T> = {
     (): T;
-    set(v: T | ((initialValue: T) => T)): void;
+    set(v: T | ((previousValue: T) => T)): void;
 };
 declare function signal<T>(initialValue: T): Signal<T>;
 declare function augmentor(updateFn: () => void, fn: () => void): () => void;

--- a/dist/src/augment.d.ts
+++ b/dist/src/augment.d.ts
@@ -1,6 +1,6 @@
 type Signal<T> = {
     (): T;
-    set(v: T | ((previousValue: T) => T)): void;
+    set(value: T | ((previousValue: T) => T)): void;
 };
 declare function signal<T>(initialValue: T): Signal<T>;
 declare function augmentor(updateFn: () => void, fn: () => void): () => void;

--- a/dist/src/registerElement.js
+++ b/dist/src/registerElement.js
@@ -70,7 +70,9 @@ const registerElement = async (options, target) => {
             rendererInstance.emitEvent = (eventName, data) => {
                 this.emitEvent(eventName, data);
             };
-            this.klass = instantiate(proxifiedClass(this.setRenderIntoQueue, target), options.deps, rendererInstance);
+            this.internalSubscriptions.add(augmentor(this.setRenderIntoQueue, () => {
+                this.klass = instantiate(proxifiedClass(this.setRenderIntoQueue, target), options.deps, rendererInstance);
+            }));
         }
         update() {
             const renderValue = this.klass.render();
@@ -118,9 +120,7 @@ const registerElement = async (options, target) => {
             this.internalSubscriptions.add(fromEvent(window, 'onLanguageChange', () => {
                 this.update();
             }));
-            if (this.klass.beforeMount) {
-                this.internalSubscriptions.add(augmentor(this.setRenderIntoQueue, this.klass.beforeMount.bind(this.klass)));
-            }
+            this.klass.beforeMount?.();
             this.update();
             this.klass.mount?.();
         }

--- a/src/augment.ts
+++ b/src/augment.ts
@@ -6,7 +6,7 @@ let token = null;
 
 type Signal<T> = {
   (): T;
-  set(v: T | ((initialValue: T) => T)): void;
+  set(v: T | ((previousValue: T) => T)): void;
 };
 
 function signalWrapper(updateFn: () => void, fn: () => void): string {
@@ -31,7 +31,7 @@ function signal<T>(initialValue: T): Signal<T> {
   }
   boundSignal.set = function (v: T | ((initialValue: T) => T)) {
     if (isFunction(v)) {
-      value = (v as (initialValue: T) => T)(value);
+      value = (v as (previousValue: T) => T)(value);
     } else {
       value = v as T;
     }

--- a/src/augment.ts
+++ b/src/augment.ts
@@ -6,7 +6,7 @@ let token = null;
 
 type Signal<T> = {
   (): T;
-  set(v: T | ((previousValue: T) => T)): void;
+  set(value: T | ((previousValue: T) => T)): void;
 };
 
 function signalWrapper(updateFn: () => void, fn: () => void): string {

--- a/src/registerElement.ts
+++ b/src/registerElement.ts
@@ -90,7 +90,11 @@ const registerElement = async (options: ComponentDecoratorOptions, target: Parti
         rendererInstance.emitEvent = (eventName: string, data: any) => {
           this.emitEvent(eventName, data);
         };
-        this.klass = instantiate(proxifiedClass(this.setRenderIntoQueue, target), options.deps, rendererInstance);
+        this.internalSubscriptions.add(
+          augmentor(this.setRenderIntoQueue, () => {
+            this.klass = instantiate(proxifiedClass(this.setRenderIntoQueue, target), options.deps, rendererInstance);
+          })
+        );
       }
 
       update() {
@@ -149,9 +153,7 @@ const registerElement = async (options: ComponentDecoratorOptions, target: Parti
             this.update();
           })
         );
-        if (this.klass.beforeMount) {
-          this.internalSubscriptions.add(augmentor(this.setRenderIntoQueue, this.klass.beforeMount.bind(this.klass)));
-        }
+        this.klass.beforeMount?.();
         this.update();
         this.klass.mount?.();
       }


### PR DESCRIPTION
With this change, devs don't need to create signal in beforeMount lifecycle hook. they can create signal at time of declaring a value or in constructor.